### PR TITLE
feat: add name/address form with submit & clear; centered layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,59 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hello, World!</title>
-  <link rel="stylesheet" href="style.css" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Hello World</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Hello, World!</h1>
+  <main class="card" role="main">
+    <h1>Hello, World!</h1>
+    <p class="subtitle">A tiny demo form.</p>
+
+    <form id="helloForm" novalidate>
+      <div class="form-row">
+        <label for="name">Name</label>
+        <input id="name" name="name" type="text" required autocomplete="name" placeholder="Your name">
+      </div>
+
+      <div class="form-row">
+        <label for="address">Address</label>
+        <input id="address" name="address" type="text" required autocomplete="street-address" placeholder="Your address">
+      </div>
+
+      <div class="buttons">
+        <button type="submit">Submit</button>
+        <button type="button" id="clearBtn">Clear</button>
+      </div>
+    </form>
+
+    <div id="result" class="result" role="status" aria-live="polite"></div>
+
+    <footer class="footer">© mfonghome/AITime</footer>
+  </main>
+
+  <script>
+    const form = document.getElementById('helloForm');
+    const clearBtn = document.getElementById('clearBtn');
+    const result = document.getElementById('result');
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const name = document.getElementById('name').value.trim();
+      const address = document.getElementById('address').value.trim();
+
+      if (!name || !address) {
+        result.textContent = 'Please fill in both fields.';
+        return;
+      }
+      result.textContent = `Thanks, ${name}! We captured your address: ${address}.`;
+    });
+
+    clearBtn.addEventListener('click', () => {
+      form.reset();
+      result.textContent = '';
+    });
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,16 +1,53 @@
-html, body {
-  height: 100%;
-  margin: 0;
-}
-
+:root { --radius: 16px; --pad: 24px; --gap: 12px; }
+* { box-sizing: border-box; }
+html, body { height: 100%; }
 body {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: system-ui, sans-serif;
-  text-align: center;
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  background: #f6f7f9;
+  color: #111;
+  display: flex; align-items: center; justify-content: center;
 }
+.card {
+  width: min(640px, 92vw);
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: 0 8px 30px rgba(0,0,0,.08);
+  padding: clamp(16px, 3vw, var(--pad));
+}
+h1 { margin: 0 0 4px; font-size: clamp(24px, 4vw, 32px); }
+.subtitle { margin: 0 0 20px; color: #444; }
 
-h1 {
-  font-size: clamp(2rem, 8vw, 4rem);
+.form-row { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; }
+label { font-weight: 600; }
+input[type="text"] {
+  padding: 10px 12px;
+  border: 1px solid #d0d7de;
+  border-radius: 10px;
+  font-size: 16px;
+}
+input[type="text"]:focus { outline: 2px solid #99c2ff; border-color: #99c2ff; }
+
+.buttons { display: flex; gap: var(--gap); margin-top: 6px; }
+button {
+  appearance: none;
+  border: 1px solid #d0d7de;
+  background: #fbfbfb;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 16px; cursor: pointer;
+}
+button:hover { background: #f0f2f5; }
+.result { margin-top: 14px; min-height: 1.25em; }
+
+.footer { margin-top: 18px; font-size: 12px; color: #666; text-align: center; }
+
+@media (prefers-color-scheme: dark) {
+  body { background: #0b0f14; color: #e8e8e8; }
+  .card { background: #0f1620; box-shadow: 0 8px 30px rgba(0,0,0,.35); }
+  input[type="text"] { background: #0b0f14; color: #e8e8e8; border-color: #2b3440; }
+  input[type="text"]:focus { outline-color: #3b82f6; border-color: #3b82f6; }
+  button { background: #14202b; border-color: #2b3440; color: #e8e8e8; }
+  button:hover { background: #192534; }
+  .subtitle, .footer { color: #a8b3c2; }
 }


### PR DESCRIPTION
## Summary
- add centered card layout with name and address fields
- include submit to show confirmation and clear button to reset
- implement responsive light/dark CSS

## Testing
- `git status --short`
- `git commit -m "feat: add name/address form with submit & clear; centered layout"`


------
https://chatgpt.com/codex/tasks/task_e_68993c27b9d8832daad569b406e0fdc7