### PR TITLE
Persist form submissions to localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <main class="card" role="main">
     <h1>Hello, World!</h1>
-    <p class="subtitle">A tiny demo form.</p>
+    <p class="subtitle">A tiny demo form with local storage.</p>
 
     <form id="helloForm" novalidate>
       <div class="form-row">
@@ -30,13 +30,91 @@
 
     <div id="result" class="result" role="status" aria-live="polite"></div>
 
+    <section class="saved">
+      <div class="saved__header">
+        <h2>Saved locally</h2>
+        <div class="saved__actions">
+          <button id="exportBtn" type="button" class="secondary">Export JSON</button>
+          <button id="clearAllBtn" type="button" class="danger">Clear All</button>
+        </div>
+      </div>
+      <div id="emptyMsg" class="muted">No saved entries yet.</div>
+      <table id="savedTable" class="table" aria-label="Saved entries" hidden>
+        <thead>
+          <tr><th style="width:30%">Name</th><th style="width:50%">Address</th><th style="width:20%">Actions</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
     <footer class="footer">© mfonghome/AITime</footer>
   </main>
 
   <script>
+    const STORAGE_KEY = 'aitime_submissions_v1';
+
     const form = document.getElementById('helloForm');
     const clearBtn = document.getElementById('clearBtn');
     const result = document.getElementById('result');
+    const savedTable = document.getElementById('savedTable');
+    const tbody = savedTable.querySelector('tbody');
+    const emptyMsg = document.getElementById('emptyMsg');
+    const exportBtn = document.getElementById('exportBtn');
+    const clearAllBtn = document.getElementById('clearAllBtn');
+
+    function loadEntries() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : [];
+      } catch {
+        return [];
+      }
+    }
+
+    function saveEntries(entries) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    }
+
+    function renderEntries() {
+      const entries = loadEntries();
+      tbody.innerHTML = '';
+
+      if (!entries.length) {
+        savedTable.hidden = true;
+        emptyMsg.style.display = 'block';
+        return;
+      }
+
+      savedTable.hidden = false;
+      emptyMsg.style.display = 'none';
+
+      entries.forEach((e, idx) => {
+        const tr = document.createElement('tr');
+        const tdName = document.createElement('td');
+        const tdAddr = document.createElement('td');
+        const tdAct = document.createElement('td');
+
+        tdName.textContent = e.name;
+        tdAddr.textContent = e.address;
+
+        const delBtn = document.createElement('button');
+        delBtn.type = 'button';
+        delBtn.className = 'danger';
+        delBtn.textContent = 'Delete';
+        delBtn.addEventListener('click', () => {
+          const next = loadEntries();
+          next.splice(idx, 1);
+          saveEntries(next);
+          renderEntries();
+        });
+
+        tdAct.appendChild(delBtn);
+        tr.appendChild(tdName);
+        tr.appendChild(tdAddr);
+        tr.appendChild(tdAct);
+        tbody.appendChild(tr);
+      });
+    }
 
     form.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -47,13 +125,42 @@
         result.textContent = 'Please fill in both fields.';
         return;
       }
-      result.textContent = `Thanks, ${name}! We captured your address: ${address}.`;
+
+      const entries = loadEntries();
+      entries.push({ name, address, ts: new Date().toISOString() });
+      saveEntries(entries);
+      renderEntries();
+
+      result.textContent = `Saved locally for ${name}.`;
+      form.reset();
     });
 
     clearBtn.addEventListener('click', () => {
       form.reset();
       result.textContent = '';
     });
+
+    exportBtn.addEventListener('click', () => {
+      const data = JSON.stringify(loadEntries(), null, 2);
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'aitime-submissions.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+
+    clearAllBtn.addEventListener('click', () => {
+      if (confirm('Delete all saved entries from this browser?')) {
+        localStorage.removeItem(STORAGE_KEY);
+        renderEntries();
+        result.textContent = '';
+      }
+    });
+
+    // Render existing on load
+    renderEntries();
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ body {
   display: flex; align-items: center; justify-content: center;
 }
 .card {
-  width: min(640px, 92vw);
+  width: min(760px, 94vw);
   background: #fff;
   border-radius: var(--radius);
   box-shadow: 0 8px 30px rgba(0,0,0,.08);
@@ -38,9 +38,19 @@ button {
   font-size: 16px; cursor: pointer;
 }
 button:hover { background: #f0f2f5; }
-.result { margin-top: 14px; min-height: 1.25em; }
+button.secondary { border-style: dashed; }
+button.danger { border-color: #e8b2b2; background: #fff6f6; }
+button.danger:hover { background: #ffecec; }
 
+.result { margin-top: 14px; min-height: 1.25em; }
 .footer { margin-top: 18px; font-size: 12px; color: #666; text-align: center; }
+
+.saved { margin-top: 20px; }
+.saved__header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.saved__actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+.table th, .table td { border-top: 1px solid #e5e7eb; padding: 10px 8px; text-align: left; }
+.muted { color: #666; font-size: 14px; }
 
 @media (prefers-color-scheme: dark) {
   body { background: #0b0f14; color: #e8e8e8; }
@@ -49,5 +59,8 @@ button:hover { background: #f0f2f5; }
   input[type="text"]:focus { outline-color: #3b82f6; border-color: #3b82f6; }
   button { background: #14202b; border-color: #2b3440; color: #e8e8e8; }
   button:hover { background: #192534; }
-  .subtitle, .footer { color: #a8b3c2; }
+  .subtitle, .footer, .muted { color: #a8b3c2; }
+  .table th, .table td { border-color: #233040; }
+  button.danger { border-color: #704a4a; background: #2a1717; }
+  button.danger:hover { background: #341d1d; }
 }


### PR DESCRIPTION
## Summary
- store form entries in browser localStorage and list them with export/delete options
- style table and buttons for saved entry management

## Testing
- `files=$(git ls-files '*.py'); if [ -n "$files" ]; then python -m py_compile $files; fi`


------
https://chatgpt.com/codex/tasks/task_e_6899488f4a54832d8cd1d4f6c66e9482